### PR TITLE
LilyPond 2.23.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ When you launch it the first time, Frescobaldi will detect only the stable
 version, installed in `/app/bin` (which has higher priority in the PATH
 environment variable).
 In order to use the unstable version of LilyPond, you must manually add
-the path `/app/lilypond-unstable/bin/lilypond` in *LilyPond Preferences*.
+the path `/app/dev/bin/lilypond` in *LilyPond Preferences*.
 
 
 ## Beta branch

--- a/org.frescobaldi.Frescobaldi.yaml
+++ b/org.frescobaldi.Frescobaldi.yaml
@@ -14,7 +14,7 @@ command: frescobaldi
 
 finish-args:
   - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
-  - --env=PATH=/app/bin:/app/lilypond-unstable/bin:/usr/bin
+  - --env=PATH=/app/bin:/app/dev/bin:/usr/bin
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=xdg-music
@@ -155,15 +155,34 @@ modules:
         x86_64:
           prepend-path: /usr/lib/sdk/texlive/bin/x86_64-linux:/usr/lib/sdk/texlive/bin
 
+  - name: guile2
+    modules:
+      - name: gc
+        config-opts:
+          - --disable-docs
+        sources:
+          - type: archive
+            url: https://www.hboehm.info/gc/gc_source/gc-8.0.6.tar.gz
+            sha256: 3b4914abc9fa76593596773e4da671d7ed4d5390e3d46fbf2e5f155e121bea11
+    buildsystem: autotools
+    config-opts:
+      - --without-threads
+      - --disable-networking
+      - --disable-error-on-warning
+    sources:
+      - type: archive
+        url: https://ftp.gnu.org/gnu/guile/guile-2.2.7.tar.xz
+        sha256: cdf776ea5f29430b1258209630555beea6d2be5481f9da4d64986b077ff37504
+
   - name: lilypond-dev
     buildsystem: autotools
     config-opts:
       - --disable-documentation
-      - --prefix=/app/lilypond-unstable
+      - --prefix=/app/dev
     sources:
       - type: archive
-        url: https://lilypond.org/download/sources/v2.23/lilypond-2.23.6.tar.gz
-        sha256: a179bd974a0e64390efef5bb0cc1e7287f1218237548433adba51c4f25bba2ce
+        url: https://lilypond.org/download/sources/v2.23/lilypond-2.23.7.tar.gz
+        sha256: b5674df4c2371cb6d59a06ea54eaba6c87f2e7c503c9f17ec3db3facd61807c0
     build-options:
       arch:
         aarch64:


### PR DESCRIPTION
First release switching to Guile 2.

The size increased about 45 MB:

```
$ flatpak info org.frescobaldi.Frescobaldi//stable | grep Installed
   Installed: 298.4 MB

$ flatpak info org.frescobaldi.Frescobaldi//master | grep Installed
   Installed: 345.4 MB
```
