### PR TITLE
Various fixes to LilyPond 2.23.x installation

### DIFF
--- a/org.frescobaldi.Frescobaldi.yaml
+++ b/org.frescobaldi.Frescobaldi.yaml
@@ -179,12 +179,17 @@ modules:
       - type: archive
         url: https://ftp.gnu.org/gnu/guile/guile-2.2.7.tar.xz
         sha256: cdf776ea5f29430b1258209630555beea6d2be5481f9da4d64986b077ff37504
+      - type: patch
+        path: patches/guile2-never-recompile.patch
 
   - name: lilypond-dev
-    buildsystem: autotools
-    config-opts:
-      - --disable-documentation
-      - --prefix=/app/dev
+    buildsystem: simple
+    build-commands:
+      - ./configure --disable-documentation --prefix=/app/dev --enable-cairo-backend
+      - make
+      - make bytecode
+      - make install
+      - make install-bytecode
     sources:
       - type: archive
         url: https://lilypond.org/download/sources/v2.23/lilypond-2.23.14.tar.gz

--- a/patches/guile2-never-recompile.patch
+++ b/patches/guile2-never-recompile.patch
@@ -1,0 +1,13 @@
+diff --git a/libguile/load.c b/libguile/load.c
+index c209812dc..725fe5ae3 100644
+--- a/libguile/load.c
++++ b/libguile/load.c
+@@ -570,7 +570,7 @@ compiled_is_fresh (SCM full_filename, SCM compiled_filename,
+       scm_puts ("\n", scm_current_warning_port ());
+     }
+ 
+-  return compiled_is_newer;
++  return 1;
+ }
+ 
+ static SCM


### PR DESCRIPTION
Enable the Cairo backend.

Compile Scheme files into bytecode to offset the performance penalty of Guile 2.2, see:
https://lilypond.org/doc/v2.23/Documentation/changes-big-page.html

Patch Guile so that Scheme files are never recompiled to .go files. The problem is that Flatpak doesn't preserve timestamps: https://github.com/flatpak/flatpak/issues/3064

Without this patch to Guile, LilyPond hangs forever while trying to rebuild files which cannot be modified in the sandbox.