### PR TITLE
Disable also the check

### DIFF
--- a/patches/guile2-never-recompile.patch
+++ b/patches/guile2-never-recompile.patch
@@ -1,13 +1,22 @@
 diff --git a/libguile/load.c b/libguile/load.c
-index c209812dc..725fe5ae3 100644
+index c209812dc..05f47c09e 100644
 --- a/libguile/load.c
 +++ b/libguile/load.c
-@@ -570,7 +570,7 @@ compiled_is_fresh (SCM full_filename, SCM compiled_filename,
+@@ -550,6 +550,7 @@ static int
+ compiled_is_fresh (SCM full_filename, SCM compiled_filename,
+                    struct stat *stat_source, struct stat *stat_compiled)
+ {
++  return 1;
+   int compiled_is_newer;
+   struct timespec source_mtime, compiled_mtime;
+ 
+@@ -569,8 +570,6 @@ compiled_is_fresh (SCM full_filename, SCM compiled_filename,
+       scm_display (compiled_filename, scm_current_warning_port ());
        scm_puts ("\n", scm_current_warning_port ());
      }
- 
+-
 -  return compiled_is_newer;
-+  return 1;
  }
  
  static SCM
+


### PR DESCRIPTION
In commit 4164212500bc9697d401114d08652d759571eace I disabled the recompilation, but LilyPond is still printing a lot of annoying messages saying that .scm files are newer than the respective compiled .go files.

So I'd better remove the whole function.