### PR TITLE
LilyPond 2.23.81

### DIFF
--- a/org.frescobaldi.Frescobaldi.yaml
+++ b/org.frescobaldi.Frescobaldi.yaml
@@ -192,8 +192,8 @@ modules:
       - make install-bytecode
     sources:
       - type: archive
-        url: https://lilypond.org/download/sources/v2.23/lilypond-2.23.80.tar.gz
-        sha256: 2b0c80d4ca73a7208eb593682a0cef79bae5ee86780f3c24b18c995c9264cff9
+        url: https://lilypond.org/download/sources/v2.23/lilypond-2.23.81.tar.gz
+        sha256: 7428b9a7e4712b775ce456dfc9ea985c092b293231f76314db3d815cf9f1f4b1
     build-options:
       arch:
         aarch64:


### PR DESCRIPTION
This is the second release candidate towards the next stable version 2.24.0 expected in December.