### PR TITLE
LilyPond 2.23.82

### DIFF
--- a/org.frescobaldi.Frescobaldi.yaml
+++ b/org.frescobaldi.Frescobaldi.yaml
@@ -192,8 +192,8 @@ modules:
       - make install-bytecode
     sources:
       - type: archive
-        url: https://lilypond.org/download/sources/v2.23/lilypond-2.23.81.tar.gz
-        sha256: 7428b9a7e4712b775ce456dfc9ea985c092b293231f76314db3d815cf9f1f4b1
+        url: https://lilypond.org/download/sources/v2.23/lilypond-2.23.82.tar.gz
+        sha256: 043c736ffe4e783dbb3b134d38192f87fe78d2bd2a8287c7cbbdfd7acc5a22c3
     build-options:
       arch:
         aarch64:


### PR DESCRIPTION
This is the third release candidate towards the next stable version 2.24.0 expected in December.