### PR TITLE
Copy .mo files to /app/share/locale

### DIFF
--- a/org.frescobaldi.Frescobaldi.yaml
+++ b/org.frescobaldi.Frescobaldi.yaml
@@ -257,6 +257,8 @@ modules:
       - cp linux/org.frescobaldi.Frescobaldi.desktop /app/share/applications/
       - cp linux/org.frescobaldi.Frescobaldi.metainfo.xml /app/share/metainfo/
       - cp frescobaldi/icons/org.frescobaldi.Frescobaldi.svg /app/share/icons/hicolor/scalable/apps/
+      # mo files must be in /app/share/locale for the translations metadata (built by appstreamcli compose) to be correct
+      - cd frescobaldi/i18n && for mo in $(find . -name "*.mo"); do install -D "$mo" "/app/share/locale/$mo"; done
     sources:
       - type: archive
         url: https://github.com/frescobaldi/frescobaldi/releases/download/v4.0.4/frescobaldi-4.0.4.tar.gz


### PR DESCRIPTION
`appstreamcli compose` generates translation metadata so that software centers can warn users if the app is not translated into their language. It expects the .mo files created by gettext to be in /app/share/locale.

* https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#translations
* https://discourse.flathub.org/t/application-languages-not-available-in-flathub-appstream-xml/10124